### PR TITLE
fix(AreaSelectInput): reset area select when selected option empty

### DIFF
--- a/src/components/blocks/FormInput/AreaSelectInput.tsx
+++ b/src/components/blocks/FormInput/AreaSelectInput.tsx
@@ -42,6 +42,8 @@ const AreaSelectInput: React.FC<AreaSelectInputProps> = ({
           selectedSido as unknown as keyof typeof KOREA_ADMNISTRATIVE_DISTRICT
         ]
       );
+    } else {
+      setCurrentSiGunGu([]);
     }
   }, [selectedSido]);
 


### PR DESCRIPTION
- Fix area selector error by reseting states when selecting 'all' in area-select box